### PR TITLE
Небольшая правка в файле shopkeeper.js

### DIFF
--- a/assets/snippets/shopkeeper/js/shopkeeper.js
+++ b/assets/snippets/shopkeeper/js/shopkeeper.js
@@ -514,8 +514,6 @@ $(document).ready(function(){
 
 })(jQuery);
 
-
-if(jQuery.browser.msie && jQuery.browser.version=='6.0'){
+if(jQuery.support.opacity){
   document.execCommand("BackgroundImageCache",false,true);
 }
-


### PR DESCRIPTION
Заменил значение $.browser, удаленный в свежих версиях jQuery, на
поддерживаемый $.support в файле  shopkeeper.js (исправление бага с прозрачностью в IE)
